### PR TITLE
Fix #28: Flexbox stretching issue

### DIFF
--- a/src/Matter/Artwork.elm
+++ b/src/Matter/Artwork.elm
@@ -397,6 +397,7 @@ callToAction pagePath model data =
             [ T.mx_auto
             , T.flex
             , T.flex_col
+            , T.items_center
 
             -- Responsive
             -------------


### PR DESCRIPTION
Safari has weird behaviour with flexbox items:

The default align-items: stretch is implemented in a way that
makes e.g. images have the initial height.
(Only happens in flex rows)

Some info: https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari