### PR TITLE
Fix: update homepage img alignment

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -72,8 +72,8 @@
             </div>
 -->
             <div aria-label="ucans" class="-mb-2 lg:-mb-10 hashed-border dark:hashed-border-dark md:hashed-border-lg md:dark:hashed-border-lg-dark">
-                <div class="flex flex-col justify-between items-center md:flex-row p-10 md:p-12 bg-neutral-100 dark:bg-neutral-700">
-                    <img src="{{ "/images/ucan.png" | relativePath(page) }}" class="w-auto inline-block mb-6 md:mb-0 md:mr-11" alt="UCAN logo" />
+                <div class="flex flex-col justify-between items-center md:flex-row md:flex-row-reverse p-10 md:p-12 bg-neutral-100 dark:bg-neutral-700">
+                    <img src="{{ "/images/ucan.png" | relativePath(page) }}" class="w-auto inline-block mb-6 md:mb-0 md:ml-11" alt="UCAN logo" />
                     <div>
                         <h4 class="text-neutral-800 dark:text-neutral-50 text-xl md:text-2xl font-display mb-2">UCANs: decentralized authorization</h4>
                         <p class="text-neutral-600 dark:text-neutral-300 text-lg md:text-xl font-body"><a href="https://ucan.xyz/" target="_blank" class="underline text-newpurple-500 dark:text-newpurple-200">UCANs</a> extend JWTs to enable distributed identity (<a href="https://www.w3.org/TR/did-core/" target="_blank" class="underline text-newpurple-500 dark:text-newpurple-200">DIDs</a>) and authorization in local-first apps & distributed systems. They make passwordless interop between apps trustless & simple—like OAuth but small, light and decentralized. They have been adopted by <a href="https://nft.storage" target="_blank" class="underline text-newpurple-500 dark:text-newpurple-200">NFT.Storage</a> & <a href="https://blueskyweb.org/" target="_blank" class="underline text-newpurple-500 dark:text-newpurple-200">Bluesky</a>.</p>
@@ -82,9 +82,9 @@
             </div>
 
             <div aria-label="webnative" class="hashed-border dark:hashed-border-dark md:hashed-border-lg md:dark:hashed-border-lg-dark">
-                <div class="flex flex-col justify-between items-center md:flex-row md:flex-row-reverse p-10 md:p-12 bg-neutral-100 dark:bg-neutral-700">
-                    <img src="{{ "/images/webnative-dark.svg" | relativePath(page) }}" class="w-auto hidden dark:inline-block mb-6 md:mb-0 md:ml-11" alt="Webnative icon" />
-                    <img src="{{ "/images/webnative-light.svg" | relativePath(page) }}" class="w-auto inline-block dark:hidden mb-6 md:mb-0 md:ml-11" alt="Webnative icon" />
+                <div class="flex flex-col justify-between items-center md:flex-row p-10 md:p-12 bg-neutral-100 dark:bg-neutral-700">
+                    <img src="{{ "/images/webnative-dark.svg" | relativePath(page) }}" class="hidden dark:inline-block w-auto inline-block mb-6 md:mb-0 md:mr-11" alt="Webnative icon" />
+                    <img src="{{ "/images/webnative-light.svg" | relativePath(page) }}" class="inline-block dark:hidden w-auto inline-block mb-6 md:mb-0 md:mr-11" alt="Webnative icon" />
                     <div>
                         <h4 class="text-neutral-800 dark:text-neutral-50 text-xl md:text-2xl font-display mb-2">WebNative SDK: a true local-first edge computing stack</h4>
                         <p class="text-neutral-600 dark:text-neutral-300 text-lg md:text-xl font-body">The <a href="https://guide.fission.codes/developers/webnative" target="_blank" class="underline text-newpurple-500 dark:text-newpurple-200">WebNative SDK</a> empowers developers to build fully distributed web applications without needing a complex back-end. <a href="https://fission.codes/apps/" target="_blank" class="underline text-newpurple-500 dark:text-newpurple-200">WebNative applications</a> work offline and store data encrypted for the user by leveraging UCANs, IPFS and the power of the web platform.</p>


### PR DESCRIPTION
# Description

Updating the alignment of the images in the homepage blocks to work now that the laconic block has been removed 

## Link to issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Screencaps

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/1179291/167896058-ed5e9534-2b8a-4bde-86ec-add1691bf548.png">

