### PR TITLE
Chore: update <code> bg shades

### DIFF
--- a/src/css/stylesheet.css
+++ b/src/css/stylesheet.css
@@ -128,7 +128,7 @@ article section ol li::before {
 }
 
 article section code {
-  @apply bg-base-100 border-t border-transparent dark:bg-base-800 dark:bg-opacity-50;
+  @apply bg-base-200 border-t border-transparent dark:bg-base-500 dark:bg-opacity-50;
   font-size: 0.85em;
 }
 


### PR DESCRIPTION
# Description

Updating the bg colours of the `<code>` tags so they stand out a bit more

## Link to issue

https://github.com/fission-suite/landing-page/issues/70

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Screencaps
**Dark mode(before):**
<img width="706" alt="image" src="https://user-images.githubusercontent.com/1179291/171905458-70d75f22-665f-4de2-b8d1-f2054ed35638.png">

**Dark mode(now):**
<img width="662" alt="image" src="https://user-images.githubusercontent.com/1179291/171905220-a3be8f4d-15bb-4ff9-a843-9f5a3342613c.png">

**Light mode(before):**
<img width="665" alt="image" src="https://user-images.githubusercontent.com/1179291/171905974-60c7cd6c-abd3-4d44-b485-5662f9604db0.png">

**Light mode(now):**
<img width="694" alt="image" src="https://user-images.githubusercontent.com/1179291/171905160-77be6320-71af-4c02-920a-775a7fddc619.png">

