### PR TITLE
Chore: make hashmap image paths relative

### DIFF
--- a/src/css/stylesheet.css
+++ b/src/css/stylesheet.css
@@ -14,22 +14,22 @@ body {
 @layer utilities {
   .hashed-border {
     border-width:16px;
-    border-image:url('/images/hashmark-border-small-light.svg') 16 16 17 17;
+    border-image:url('./images/hashmark-border-small-light.svg') 16 16 17 17;
   }
 
   .hashed-border-dark {
     border-width:16px;
-    border-image:url('/images/hashmark-border-small-dark.svg') 16 16 17 17;
+    border-image:url('./images/hashmark-border-small-dark.svg') 16 16 17 17;
   }
 
   .hashed-border-lg {
     border-width:40px;
-    border-image:url('/images/hashmark-border-large-light.svg') 40 40 41 41;
+    border-image:url('./images/hashmark-border-large-light.svg') 40 40 41 41;
   }
 
   .hashed-border-lg-dark {
     border-width:40px;
-    border-image:url('/images/hashmark-border-large-dark.svg') 40 40 41 41;
+    border-image:url('./images/hashmark-border-large-dark.svg') 40 40 41 41;
   }
 }
 


### PR DESCRIPTION
# Description

Looks like the hashmap bg images on the homepage blocks were added after I did my relative path updates, so I'm updating those to make them relative 👍🏼 

## Link to issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Screencaps

**Before:**
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/1179291/173421075-d47680ee-b369-410f-bbc5-451029d7fbad.png">
**After:**
<img width="1204" alt="image" src="https://user-images.githubusercontent.com/1179291/173421133-d706e06e-b051-4904-b589-461f1c7b5200.png">

## Demo
**Standard domain:**
https://tubular-triangular-yellow-cat.fission.app/

**IPFS domain:**
https://ipfs.runfission.com/ipns/tubular-triangular-yellow-cat.fission.app/
